### PR TITLE
Fix bug with setting refresh token on refresh

### DIFF
--- a/open_banking_archiver/open_banking_client.py
+++ b/open_banking_archiver/open_banking_client.py
@@ -29,8 +29,6 @@ class OpenBankingClient(NordigenClient):
     def exchange_token(self, refresh_token: str) -> TokenType:
         token = super().exchange_token(refresh_token)
         self.token_expires = token["access_expires"]
-        self.token_refresh = token["refresh"]
-        self.token_refresh_expires = token["refresh_expires"]
         self.token_generated = datetime.now()
         return token
 


### PR DESCRIPTION
When the token is refreshed, the payload response does not include a new refresh token, only a new access token.